### PR TITLE
Refactor large widgets into reusable components

### DIFF
--- a/lib/models/ai_message.dart
+++ b/lib/models/ai_message.dart
@@ -1,0 +1,30 @@
+class AiMessage {
+  final String text;
+  final bool isUser;
+  final bool isFunctionCall;
+  final String? functionName;
+  final String? arguments;
+
+  AiMessage.user(this.text)
+      : isUser = true,
+        isFunctionCall = false,
+        functionName = null,
+        arguments = null;
+
+  AiMessage.ai(this.text)
+      : isUser = false,
+        isFunctionCall = false,
+        functionName = null,
+        arguments = null;
+
+  AiMessage.system(this.text)
+      : isUser = false,
+        isFunctionCall = false,
+        functionName = null,
+        arguments = null;
+
+  AiMessage.functionCall({required this.functionName, required this.arguments})
+      : isUser = false,
+        isFunctionCall = true,
+        text = "\uD83E\uDEA3 Casting scroll spell...";
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,3 +1,4 @@
 export 'room_type.dart';
 export 'branding.dart';
 export 'property_details.dart';
+export 'ai_message.dart';

--- a/lib/screens/chatbot_ui.dart
+++ b/lib/screens/chatbot_ui.dart
@@ -6,37 +6,8 @@ import '../models/property_details.dart';
 import 'demo_dashboard.dart';
 import '/widgets/shared/components.dart';
 import '/widgets/shared/drawer.dart';
-
-class AiMessage {
-  final String text;
-  final bool isUser;
-  final bool isFunctionCall;
-  final String? functionName;
-  final String? arguments;
-
-  AiMessage.user(this.text)
-    : isUser = true,
-      isFunctionCall = false,
-      functionName = null,
-      arguments = null;
-
-  AiMessage.ai(this.text)
-    : isUser = false,
-      isFunctionCall = false,
-      functionName = null,
-      arguments = null;
-
-  AiMessage.system(this.text)
-    : isUser = false,
-      isFunctionCall = false,
-      functionName = null,
-      arguments = null;
-
-  AiMessage.functionCall({required this.functionName, required this.arguments})
-    : isUser = false,
-      isFunctionCall = true,
-      text = "🧾 Casting scroll spell...";
-}
+import '../models/ai_message.dart';
+import '../widgets/chat/chat_message.dart';
 
 class HotelOnboardingBot extends StatefulWidget {
   const HotelOnboardingBot({super.key});
@@ -151,48 +122,7 @@ class _HotelOnboardingBotState extends State<HotelOnboardingBot> {
                     itemCount: _messages.length,
                     itemBuilder: (context, index) {
                       final msg = _messages[index];
-                      final isBot = !msg.isUser;
-                      return Align(
-                        alignment: msg.isUser
-                            ? Alignment.centerRight
-                            : Alignment.centerLeft,
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisAlignment: msg.isUser
-                              ? MainAxisAlignment.end
-                              : MainAxisAlignment.start,
-                          children: [
-                            if (isBot)
-                              Padding(
-                                padding: const EdgeInsets.only(right: 8),
-                                child: Image.asset(
-                                  'web/assets/wizard.png',
-                                  height: 32,
-                                ),
-                              ),
-                            Flexible(
-                              child: Container(
-                                margin: const EdgeInsets.symmetric(vertical: 4),
-                                padding: const EdgeInsets.all(12),
-                                decoration: BoxDecoration(
-                                  color: msg.isUser
-                                      ? Colors.indigo
-                                      : Colors.grey[200],
-                                  borderRadius: BorderRadius.circular(12),
-                                ),
-                                child: Text(
-                                  msg.text,
-                                  style: TextStyle(
-                                    color: msg.isUser
-                                        ? Colors.white
-                                        : Colors.black,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      );
+                      return ChatMessage(message: msg);
                     },
                   ),
                 ),

--- a/lib/screens/onboarding_preview.dart
+++ b/lib/screens/onboarding_preview.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/shared/RoomTypeEditorCard.dart';
 
 class OnboardingPreviewScreen extends StatelessWidget {
   const OnboardingPreviewScreen({super.key});
@@ -89,93 +90,3 @@ class OnboardingPreviewScreen extends StatelessWidget {
   }
 }
 
-class RoomTypeEditorCard extends StatelessWidget {
-  final String typeName;
-  const RoomTypeEditorCard({super.key, required this.typeName});
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              typeName,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-            ),
-            const SizedBox(height: 12),
-
-            Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    decoration: const InputDecoration(
-                      labelText: "# of Rooms",
-                      border: OutlineInputBorder(),
-                    ),
-                    keyboardType: TextInputType.number,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: TextField(
-                    decoration: const InputDecoration(
-                      labelText: "Occupancy",
-                      suffixText: "guests",
-                      border: OutlineInputBorder(),
-                    ),
-                    keyboardType: TextInputType.number,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-
-            Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    decoration: const InputDecoration(
-                      labelText: "Nightly Rate",
-                      prefixText: "\$",
-                      border: OutlineInputBorder(),
-                    ),
-                    keyboardType: TextInputType.number,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: TextField(
-                    decoration: const InputDecoration(
-                      labelText: "Cleaning Time",
-                      suffixText: "mins",
-                      border: OutlineInputBorder(),
-                    ),
-                    keyboardType: TextInputType.number,
-                  ),
-                ),
-              ],
-            ),
-
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                const Text("Upload Room Image:"),
-                const SizedBox(width: 12),
-                OutlinedButton.icon(
-                  icon: const Icon(Icons.image),
-                  label: const Text("Add Image"),
-                  onPressed: () {},
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/widgets/chat/chat_message.dart
+++ b/lib/widgets/chat/chat_message.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import '../../models/ai_message.dart';
+
+class ChatMessage extends StatelessWidget {
+  final AiMessage message;
+  const ChatMessage({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final isBot = !message.isUser;
+    return Align(
+      alignment:
+          message.isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment:
+            message.isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+        children: [
+          if (isBot)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Image.asset(
+                'web/assets/wizard.png',
+                height: 32,
+              ),
+            ),
+          Flexible(
+            child: Container(
+              margin: const EdgeInsets.symmetric(vertical: 4),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: message.isUser ? Colors.indigo : Colors.grey[200],
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                message.text,
+                style: TextStyle(
+                  color: message.isUser ? Colors.white : Colors.black,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- separate `AiMessage` model from screen logic
- create a `ChatMessage` widget for message bubbles
- use the shared `RoomTypeEditorCard` widget
- clean up imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfe5f65c48327bc9f0e01b90dbd6a