### PR TITLE
Fix room setup flow

### DIFF
--- a/lib/screens/chatbot_ui.dart
+++ b/lib/screens/chatbot_ui.dart
@@ -50,7 +50,7 @@ class _HotelOnboardingBotState extends State<HotelOnboardingBot> {
         );
         _showScrollDialog(context);
       } else {
-        _messages.add(AiMessage.custom(const AiFinalMessage()));
+        _messages.add(AiMessage.ai(chatController.prompt));
       }
 
       _textController.clear();
@@ -217,7 +217,8 @@ class _HotelOnboardingBotState extends State<HotelOnboardingBot> {
                   child: RoomTypeDrawer(
                     numberOfRoomTypes: chatController.totalRoomTypes ?? 4,
                     summaryText: '',
-                    onFinish: () {
+                    onFinish: (totalRooms) {
+                      chatController.setTotalRooms(totalRooms);
                       chatController.saveResponse('done');
                       final nextStep = chatController.currentStep;
 

--- a/lib/services/chat_controller.dart
+++ b/lib/services/chat_controller.dart
@@ -11,6 +11,7 @@ class ChatController {
   Room? _tempRoom;
   int? _totalRoomTypes = 0;
   int _currentRoomIndex = 1;
+  int _totalRooms = 0;
 
   OnboardingStep get currentStep => _currentStep;
 
@@ -22,6 +23,11 @@ class ChatController {
   Map<OnboardingStep, dynamic> get responses => _responses;
   List<Room> get rooms => _rooms;
   int? get totalRoomTypes => _totalRoomTypes;
+  int get totalRooms => _totalRooms;
+
+  void setTotalRooms(int count) {
+    _totalRooms = count;
+  }
 
   void saveResponse(dynamic value) {
     switch (_currentStep) {
@@ -61,7 +67,7 @@ class ChatController {
       propertyName: _responses[OnboardingStep.propertyName],
       propertyType: '', // No longer asked
       region: _responses[OnboardingStep.propertyLocation],
-      numberOfRooms: _rooms.length,
+      numberOfRooms: _totalRooms,
       featureFocus: List<String>.from(
         _responses[OnboardingStep.featureFocus] ?? [],
       ),
@@ -92,5 +98,6 @@ class ChatController {
     _tempRoom = null;
     _totalRoomTypes = null;
     _currentRoomIndex = 1;
+    _totalRooms = 0;
   }
 }

--- a/lib/widgets/shared/drawer.dart
+++ b/lib/widgets/shared/drawer.dart
@@ -4,7 +4,7 @@ import 'RoomTypeEditorCard.dart';
 class RoomTypeDrawer extends StatefulWidget {
   final int numberOfRoomTypes;
   final String summaryText;
-  final VoidCallback onFinish;
+  final Function(int totalRooms) onFinish;
 
   const RoomTypeDrawer({
     super.key,
@@ -43,6 +43,16 @@ class _RoomTypeDrawerState extends State<RoomTypeDrawer> {
     roomCardCount = widget.numberOfRoomTypes;
   }
 
+  @override
+  void didUpdateWidget(covariant RoomTypeDrawer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.numberOfRoomTypes != oldWidget.numberOfRoomTypes) {
+      setState(() {
+        roomCardCount = widget.numberOfRoomTypes;
+      });
+    }
+  }
+
   void addRoom() {
     setState(() {
       roomCardCount++;
@@ -58,7 +68,7 @@ class _RoomTypeDrawerState extends State<RoomTypeDrawer> {
   void completeSetup() {
     setState(() => _botTyping = true);
     Future.delayed(const Duration(milliseconds: 600), () {
-      widget.onFinish();
+      widget.onFinish(totalRooms);
       if (mounted) {
         setState(() {
           _botTyping = false;


### PR DESCRIPTION
## Summary
- fix chat flow to send next prompt rather than final message
- sync drawer room card count with user input
- pass total room count to `ChatController`
- expose room count to build property details

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0f2db57c832792810c788d4952b2