### PR TITLE
Fix finish callback type

### DIFF
--- a/lib/widgets/shared/drawer.dart
+++ b/lib/widgets/shared/drawer.dart
@@ -4,7 +4,7 @@ import 'RoomTypeEditorCard.dart';
 class RoomTypeDrawer extends StatefulWidget {
   final int numberOfRoomTypes;
   final String summaryText;
-  final Function(int totalRooms) onFinish;
+  final void Function(int totalRooms) onFinish;
 
   const RoomTypeDrawer({
     super.key,


### PR DESCRIPTION
## Summary
- make `RoomTypeDrawer.onFinish` use a typed callback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2072284c832785fb09c0d9051147